### PR TITLE
Fix error with uint8array values in kv data

### DIFF
--- a/src/buffer-reader.ts
+++ b/src/buffer-reader.ts
@@ -43,6 +43,12 @@ export class BufferReader {
 		return value;
 	}
 
+	_nextUint8Array(len: number) {
+		const value = new Uint8Array(this._dataView.buffer, this._dataView.byteOffset + this._offset, len);
+		this._offset += len;
+		return value;
+	}
+
 	_skip(bytes: number) {
 		this._offset += bytes;
 		return this;

--- a/src/read.ts
+++ b/src/read.ts
@@ -158,11 +158,12 @@ export function read(data: Uint8Array): KTX2Container {
 		const keyData = kvdReader._scan(keyValueByteLength);
 		const key = decodeText(keyData);
 
-		const valueData = kvdReader._scan(keyValueByteLength - keyData.byteLength);
-		container.keyValue[key] = key.match(/^ktx/i) ? decodeText(valueData) : valueData;
+		const valueData = kvdReader._nextUint8Array(keyValueByteLength - keyData.byteLength - 1);
+		container.keyValue[key] = key.match(/^ktx/i) ? decodeText(valueData).replace(/^(.*)\x00$/, '$1') : valueData;
 
+		const kvPadding = keyValueByteLength % 4 ? 4 - (keyValueByteLength % 4) : 0; // align(4)
 		// 4-byte alignment.
-		if (kvdReader._offset % 4) kvdReader._skip(4 - (kvdReader._offset % 4));
+		kvdReader._skip(kvPadding);
 	}
 
 	///////////////////////////////////////////////////

--- a/src/write.ts
+++ b/src/write.ts
@@ -70,8 +70,8 @@ export function write(container: KTX2Container, options: WriteOptions = {}): Uin
 	for (const key in keyValue) {
 		const value = keyValue[key];
 		const keyData = encodeText(key);
-		const valueData = typeof value === 'string' ? encodeText(value) : value;
-		const kvByteLength = keyData.byteLength + 1 + valueData.byteLength + 1;
+		const valueData = typeof value === 'string' ? concat([encodeText(value), NUL]) : value;
+		const kvByteLength = keyData.byteLength + 1 + valueData.byteLength;
 		const kvPadding = kvByteLength % 4 ? 4 - (kvByteLength % 4) : 0; // align(4)
 		keyValueData.push(
 			concat([
@@ -79,7 +79,6 @@ export function write(container: KTX2Container, options: WriteOptions = {}): Uin
 				keyData,
 				NUL,
 				valueData,
-				NUL,
 				new Uint8Array(kvPadding).fill(0x00), // align(4)
 			])
 		);

--- a/test/test.ts
+++ b/test/test.ts
@@ -246,6 +246,17 @@ test('lossless round trip', async (t) => {
 	);
 });
 
+test('read kv', (t) => {
+	const a = read(SAMPLE_ETC1S);
+	a.keyValue['TestUint8Array'] = new Uint8Array([0, 0, 0, 16]);
+	const b = write(a);
+	const c = read(b);
+	t.true(
+		typedArrayEquals(c.keyValue['TestUint8Array'] as Uint8Array, new Uint8Array([0, 0, 0, 16])),
+		'container.keyValue[TestUint8Array]'
+	);
+});
+
 function typedArrayEquals(a: Uint8Array, b: Uint8Array): boolean {
 	if (a.byteLength !== b.byteLength) return false;
 	for (let i = 0; i < a.byteLength; i++) {


### PR DESCRIPTION
Fix #78 

According to the [KTX spec](https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html):
- Key: UTF-8 encoded without BOM, terminated by a null character (0x00 byte)
- Value: Can be an arbitrary sequence of bytes (preferably a null-terminated UTF-8 string without BOM)
- Binary Value data: Sequence of bytes with multi-byte numbers in little-endian order
- String Value data: Null termination included in keyAndValueByteLength

I modified the write method. If it's a uint8array, I didn't write a termination character. And also modified the read method. If it's parsed as a string, I replaced the termination character (if any) using regex.